### PR TITLE
Atualização e Edição de Perfil (backend)

### DIFF
--- a/ConexaoCaninaApp/ConexaoCaninaApp.API/Controllers/CaoController.cs
+++ b/ConexaoCaninaApp/ConexaoCaninaApp.API/Controllers/CaoController.cs
@@ -40,6 +40,13 @@ namespace ConexaoCaninaApp.API.Controllers
 		{
 			await _caoService.AprovarCao(id);
 			return NoContent();
-		}		
+		}
+
+		[HttpPut("editar")]
+		public async Task<IActionResult> EditarCao([FromBody] EditarCaoDto editarCaoDto)
+		{
+			await _caoService.AtualizarCao(editarCaoDto);
+			return Ok();
+		}
 	}
 }

--- a/ConexaoCaninaApp/ConexaoCaninaApp.Application/Dto/EditarCaoDto.cs
+++ b/ConexaoCaninaApp/ConexaoCaninaApp.Application/Dto/EditarCaoDto.cs
@@ -1,0 +1,17 @@
+﻿using ConexaoCaninaApp.Domain.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ConexaoCaninaApp.Application.Dto
+{
+	public class EditarCaoDto
+	{
+		public int CaoId { get; set; }
+		public int Idade { get; set; }
+		public string Descricao { get; set; }
+		public string CaracteristicasUnicas { get; set; }
+	}
+}

--- a/ConexaoCaninaApp/ConexaoCaninaApp.Application/Interfaces/ICaoService.cs
+++ b/ConexaoCaninaApp/ConexaoCaninaApp.Application/Interfaces/ICaoService.cs
@@ -13,5 +13,6 @@ namespace ConexaoCaninaApp.Application.Interfaces
 		Task<Cao> AdicionarCao(CaoDto caoDto);
 		Task AprovarCao(int caoId);
 		Task<Cao> ObterPorId(int id);
+		Task AtualizarCao(EditarCaoDto editarCaoDto);
 	}
 }

--- a/ConexaoCaninaApp/ConexaoCaninaApp.Application/Services/CaoService.cs
+++ b/ConexaoCaninaApp/ConexaoCaninaApp.Application/Services/CaoService.cs
@@ -55,5 +55,23 @@ namespace ConexaoCaninaApp.Application.Services
 		{
 			return await _caoRepository.ObterPorId(id);
 		}
+
+		public async Task AtualizarCao(EditarCaoDto editarCaoDto)
+		{
+			var cao = await _caoRepository.ObterPorId(editarCaoDto.CaoId);
+
+			if (cao !=  null)
+			{
+				cao.Idade = editarCaoDto.Idade;
+				cao.Descricao = editarCaoDto.Descricao;
+				cao.CaracteristicasUnicas = editarCaoDto.CaracteristicasUnicas;
+
+				cao.Status = StatusCao.Pendente;
+
+				await _caoRepository.Atualizar(cao);
+
+				await _notificacaoService.EnviarNotificacaoParaAdministrador(cao);
+			}
+		}
 	}
 }

--- a/ConexaoCaninaApp/ConexaoCaninaApp.Domain.Test/CaoServiceTests.cs
+++ b/ConexaoCaninaApp/ConexaoCaninaApp.Domain.Test/CaoServiceTests.cs
@@ -134,6 +134,41 @@ namespace ConexaoCaninaApp.Domain.Test
 			_mockNotificacaoService.Verify(notif => notif.EnviarNotificacaoParaUsuario(It.IsAny<Cao>()), Times.Once);
 			Assert.Equal(StatusCao.Aprovado, caoExistente.Status);
 		}
+
+		[Fact]
+		public async Task EditarPerfil_Deve_Definir_Status_Pendente_E_Notificar_Administrador()
+		{
+			// ARRANGE
+			var editarCaoDto = new EditarCaoDto
+			{
+				CaoId = 1,
+				Idade = 5,
+				Descricao = "Lindo, forte e adoravel",
+				CaracteristicasUnicas = "Forte"
+			};
+
+			var caoExistente = new Cao
+			{
+				CaoId = 1,
+				Nome = "General PHG",
+				Idade = 3,
+				Status = StatusCao.Aprovado
+			};
+
+			_mockCaoRepository.Setup(repo => repo.ObterPorId(editarCaoDto.CaoId))
+				.ReturnsAsync(caoExistente);
+
+			// ACT
+
+			await _caoService.AtualizarCao(editarCaoDto);
+
+			// ASSERT
+			_mockCaoRepository.Verify(repo => repo.Atualizar
+			(It.Is<Cao>(c => c.Status == StatusCao.Pendente)), Times.Once);
+			_mockNotificacaoService.Verify(serv => serv.EnviarNotificacaoParaAdministrador
+			(It.IsAny<Cao>()), Times.Once);
+
+		}
 	}
 }
 


### PR DESCRIPTION
Atualizamos o CaoService para incluir o método de edição do perfil, que marca o status como "Pendente" e envia a notificação para o administrador.
Atualizamos o CaoController para expor a rota de edição (PUT /editar).
Criamos o EditarCaoDto para garantir que apenas os campos editáveis sejam enviados na requisição.
Adicionamos testes unitários para garantir o correto funcionamento da lógica de edição e notificação.