### PR TITLE
Adicionando Funcionalidade de Reprovar Status Cão

### DIFF
--- a/ConexaoCaninaApp/ConexaoCaninaApp.API/Controllers/CaoController.cs
+++ b/ConexaoCaninaApp/ConexaoCaninaApp.API/Controllers/CaoController.cs
@@ -106,5 +106,12 @@ namespace ConexaoCaninaApp.API.Controllers
 		}
 
 		// Rejeitar Status de Cao -> Rejeitado
+		[HttpPost]
+		[Route("{id}/reprovar")]
+		public async Task<IActionResult> ReprovarCao(Guid id)
+		{
+			var result = _caoService.ReprovarCao(id);
+			return Ok();
+		}
 	}
 }

--- a/ConexaoCaninaApp/ConexaoCaninaApp.Application/Services/ICaoService.cs
+++ b/ConexaoCaninaApp/ConexaoCaninaApp.Application/Services/ICaoService.cs
@@ -15,6 +15,7 @@ namespace ConexaoCaninaApp.Application.Services
 		bool AlterarIdade(Guid id, int idade);
 		CaoDTO GetById(Guid id);
 		bool AprovarCao(Guid id);
+		bool ReprovarCao(Guid id);
 	}
 
 	public class CaoService : ICaoService
@@ -108,5 +109,17 @@ namespace ConexaoCaninaApp.Application.Services
 				
 			};
 		}
-	}
+
+        public bool ReprovarCao(Guid id)
+        {
+            var cao = _caoRepository.GetById(id);
+
+            if (cao == null) 
+				return false;
+
+            cao.Reprovar();
+            _caoRepository.SaveChanges();
+            return true;
+        }
+    }
 }

--- a/ConexaoCaninaApp/ConexaoCaninaApp.Domain/Models/Cao.cs
+++ b/ConexaoCaninaApp/ConexaoCaninaApp.Domain/Models/Cao.cs
@@ -84,5 +84,9 @@ namespace ConexaoCaninaApp.Domain.Models
             Status = StatusCao.Aprovado;
         }
 
+        public void Reprovar()
+        {
+            Status = StatusCao.Rejeitado;
+        }
 	}
 }


### PR DESCRIPTION
implementação de uma nova funcionalidade na **_CaoController_**. Foi adicionado um endpoint que permite alterar o status de aprovação de um cão para "Rejeitado", utilizando o Id do Cão como parâmetro.

#### Alterações principais:
- Criação de um endpoint dedicado para rejeitar a aprovação de um registro de cão.
- Atualização no status de aprovação baseado no identificador único (Id) do cão informado.